### PR TITLE
Use a couple of casts to speed up the MurmurString function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ For a full description of the algorithm, see the paper HyperLogLog:
 the analysis of a near-optimal cardinality estimation algorithm by
 Flajolet, et. al. at http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
 
-For documentation see http://godoc.org/github.com/eclesh/hyperloglog
+For documentation see http://godoc.org/github.com/DataDog/hyperloglog
+
+Included are a set of fast implementations for murmurhash suitable for use
+on 32 and 64 bit integers on little endian machines.
 
 Quick start
 ===========
 
-	$ go get github.com/eclesh/hyperloglog
-	$ cd $GOPATH/src/github.com/eclesh/hyperloglog
+	$ go get github.com/DataDog/hyperloglog
+	$ cd $GOPATH/src/github.com/DataDog/hyperloglog
 	$ go test -test.v
 	$ go test -bench=.
 

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -44,11 +44,11 @@ func geterror(actual uint64, estimate uint64) (result float64) {
 	return (float64(estimate) - float64(actual)) / float64(actual)
 }
 
-func testHyperLogLog(t *testing.T, n, low_b, high_b int) {
+func testHyperLogLog(t *testing.T, n, lowB, highB int) {
 	words := dictionary(n)
 	bad := 0
-	n_words := uint64(len(words))
-	for i := low_b; i < high_b; i++ {
+	nWords := uint64(len(words))
+	for i := lowB; i < highB; i++ {
 		m := uint(math.Pow(2, float64(i)))
 
 		h, err := New(m)
@@ -63,17 +63,17 @@ func testHyperLogLog(t *testing.T, n, low_b, high_b int) {
 			hash.Reset()
 		}
 
-		expected_error := 1.04 / math.Sqrt(float64(m))
-		actual_error := math.Abs(geterror(n_words, h.Count()))
+		expectedError := 1.04 / math.Sqrt(float64(m))
+		actualError := math.Abs(geterror(nWords, h.Count()))
 
-		if actual_error > expected_error {
+		if actualError > expectedError {
 			bad++
 			t.Logf("m=%d: error=%.5f, expected <%.5f; actual=%d, estimated=%d\n",
-				m, actual_error, expected_error, n_words, h.Count())
+				m, actualError, expectedError, nWords, h.Count())
 		}
 
 	}
-	t.Logf("%d of %d tests exceeded estimated error", bad, high_b-low_b)
+	t.Logf("%d of %d tests exceeded estimated error", bad, highB-lowB)
 }
 
 func TestHyperLogLogSmall(t *testing.T) {

--- a/murmur.go
+++ b/murmur.go
@@ -56,3 +56,51 @@ func Murmur64(i uint64) uint32 {
 	h ^= h >> 16
 	return h
 }
+
+// Murmur128 implements a fast version of the murmur hash function for two uint64s
+// for little endian machines.  Suitable for adding a 128bit value to an HLL counter.
+func Murmur128(i, j uint64) uint32 {
+	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
+	var h, k uint32
+	//first 4-byte chunk
+	k = uint32(i)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second 4-byte chunk
+	k = uint32(i >> 32)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// third 4-byte chunk
+	k = uint32(j)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// fourth 4-byte chunk
+	k = uint32(j >> 32)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second part
+	h ^= 16
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+
+}

--- a/murmur.go
+++ b/murmur.go
@@ -1,0 +1,58 @@
+package hyperloglog
+
+// This file implements the murmur3 32-bit hash on 32bit and 64bit integers
+// for little endian machines only with no heap allocation.  If you are using
+// HLL to count integer IDs on intel machines, this is your huckleberry.
+
+// Murmur32 implements a fast version of the murmur hash function for uint32 for
+// little endian machines.  Suitable for adding 32bit integers to a HLL counter.
+func Murmur32(i uint32) uint32 {
+	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
+	var h, k uint32
+	k = i
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second part
+	h ^= 4
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}
+
+// Murmur64 implements a fast version of the murmur hash function for uint64 for
+// little endian machines.  Suitable for adding 64bit integers to a HLL counter.
+func Murmur64(i uint64) uint32 {
+	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
+	var h, k uint32
+	//first 4-byte chunk
+	k = uint32(i)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second 4-byte chunk
+	k = uint32(i >> 32)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second part
+	h ^= 8
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}

--- a/murmur.go
+++ b/murmur.go
@@ -1,8 +1,6 @@
 package hyperloglog
 
-import (
-	"encoding/binary"
-)
+import "unsafe"
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
 // for little endian machines only with no heap allocation.  If you are using
@@ -14,17 +12,14 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := make([]byte, len(key))
-	copy(bkey[:], key)
-
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
 	l := blen / 4 // chunk length
-	tail := bkey[l*4:]
 
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = binary.LittleEndian.Uint32(bkey[i*4:])
+		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
 
 		// encode next 4 byte chunk of `key'
 		k *= c1
@@ -37,7 +32,8 @@ func MurmurString(key string) uint32 {
 
 	k = 0
 	// remainder
-	switch len(tail) {
+	tail := bkey[l*4:]
+	switch blen % 4 {
 	case 3:
 		k ^= uint32(tail[2]) << 16
 		fallthrough

--- a/murmur.go
+++ b/murmur.go
@@ -14,9 +14,10 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := []byte(key)
-	blen := len(bkey)
+	bkey := make([]byte, len(key))
+	copy(bkey[:], key)
 
+	blen := len(bkey)
 	l := blen / 4 // chunk length
 	tail := bkey[l*4:]
 

--- a/murmur.go
+++ b/murmur.go
@@ -16,12 +16,9 @@ func MurmurString(key string) uint32 {
 	blen := len(bkey)
 	l := blen / 4 // chunk length
 
-	// for each 4 byte chunk of `key'
+	// encode each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
-		// next 4 byte chunk of `key'
 		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
-
-		// encode next 4 byte chunk of `key'
 		k *= c1
 		k = (k << 15) | (k >> (32 - 15))
 		k *= c2
@@ -31,21 +28,23 @@ func MurmurString(key string) uint32 {
 	}
 
 	k = 0
-	// remainder
-	tail := bkey[l*4:]
-	switch blen % 4 {
-	case 3:
-		k ^= uint32(tail[2]) << 16
-		fallthrough
-	case 2:
-		k ^= uint32(tail[1]) << 8
-		fallthrough
-	case 1:
-		k ^= uint32(tail[0])
-		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
-		k *= c2
-		h ^= k
+	//remainder
+	if mod := blen % 4; mod > 0 {
+		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
+		switch mod {
+		case 3:
+			k ^= ((btail >> 16) & 0x0000FFFF) << 16
+			fallthrough
+		case 2:
+			k ^= ((btail >> 8) & 0x000000FF) << 8
+			fallthrough
+		case 1:
+			k ^= btail & 0x000000FF
+			k *= c1
+			k = (k << 15) | (k >> (32 - 15))
+			k *= c2
+			h ^= k
+		}
 	}
 
 	h ^= uint32(blen)

--- a/murmur.go
+++ b/murmur.go
@@ -1,7 +1,9 @@
 package hyperloglog
 
 import (
-	"encoding/binary"
+	"reflect"
+	"runtime"
+	"unsafe"
 )
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
@@ -14,7 +16,15 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := []byte(key)
+	// Reinterpret the string as a `StringHeader`. This comes with three important caveats:
+	// 1. We must never write through the pointer derived. Golang strings are immutable and we cannot
+	//    break that assumption.
+	// 2. Golang continues to have a non-moving GC. This only works because the Golang GC is
+	//    (currently) non-moving. There are no plans to break this yet, but it remains a caveat.
+	// 3. `key` is used after the `StringHeader` is no longer needed. Currently, `runtime.KeepAlive`
+	//    is used as a no-op use.
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	bkey := *(*[]byte)(unsafe.Pointer(sh))
 	blen := len(bkey)
 
 	l := blen / 4 // chunk length
@@ -23,7 +33,7 @@ func MurmurString(key string) uint32 {
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = binary.LittleEndian.Uint32(bkey[i*4:])
+		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
 
 		// encode next 4 byte chunk of `key'
 		k *= c1
@@ -57,6 +67,9 @@ func MurmurString(key string) uint32 {
 	h ^= (h >> 13)
 	h *= 0xc2b2ae35
 	h ^= (h >> 16)
+
+	runtime.KeepAlive(&key)
+
 	return h
 }
 

--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,8 @@
 package hyperloglog
 
-import "unsafe"
+import (
+	"encoding/binary"
+)
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
 // for little endian machines only with no heap allocation.  If you are using
@@ -12,13 +14,18 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
+	bkey := []byte(key)
 	blen := len(bkey)
-	l := blen / 4 // chunk length
 
-	// encode each 4 byte chunk of `key'
+	l := blen / 4 // chunk length
+	tail := bkey[l*4:]
+
+	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
-		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
+		// next 4 byte chunk of `key'
+		k = binary.LittleEndian.Uint32(bkey[i*4:])
+
+		// encode next 4 byte chunk of `key'
 		k *= c1
 		k = (k << 15) | (k >> (32 - 15))
 		k *= c2
@@ -28,23 +35,20 @@ func MurmurString(key string) uint32 {
 	}
 
 	k = 0
-	//remainder
-	if mod := blen % 4; mod > 0 {
-		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
-		switch mod {
-		case 3:
-			k ^= ((btail >> 16) & 0x000000FF) << 16
-			fallthrough
-		case 2:
-			k ^= ((btail >> 8) & 0x000000FF) << 8
-			fallthrough
-		case 1:
-			k ^= btail & 0x000000FF
-			k *= c1
-			k = (k << 15) | (k >> (32 - 15))
-			k *= c2
-			h ^= k
-		}
+	// remainder
+	switch len(tail) {
+	case 3:
+		k ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k ^= uint32(tail[0])
+		k *= c1
+		k = (k << 15) | (k >> (32 - 15))
+		k *= c2
+		h ^= k
 	}
 
 	h ^= uint32(blen)

--- a/murmur.go
+++ b/murmur.go
@@ -33,7 +33,7 @@ func MurmurString(key string) uint32 {
 		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
 		switch mod {
 		case 3:
-			k ^= ((btail >> 16) & 0x0000FFFF) << 16
+			k ^= ((btail >> 16) & 0x000000FF) << 16
 			fallthrough
 		case 2:
 			k ^= ((btail >> 8) & 0x000000FF) << 8

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/reusee/mmh3"
+	"github.com/DataDog/mmh3"
 )
 
 var buf32 = make([]byte, 4)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,0 +1,35 @@
+package hyperloglog
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/reusee/mmh3"
+)
+
+var buf32 = make([]byte, 4)
+var buf64 = make([]byte, 8)
+
+// Test that our abbreviated murmur hash works the same as upstream
+func TestMurmur(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		x := rand.Int31()
+		binary.LittleEndian.PutUint32(buf32, uint32(x))
+		hash := mmh3.Hash32(buf32)
+		m := Murmur32(uint32(x))
+		if hash != m {
+			t.Errorf("Hash mismatch on 32 bit %d: expected 0x%X, got 0x%X\n", x, hash, m)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		x := rand.Int63()
+		binary.LittleEndian.PutUint64(buf64, uint64(x))
+		hash := mmh3.Hash32(buf64)
+		m := Murmur64(uint64(x))
+		if hash != m {
+			t.Errorf("Hash mismatch on 64 bit %d: expected 0x%X, got 0x%X\n", x, hash, m)
+		}
+	}
+}

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -46,8 +47,8 @@ func TestMurmur(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 100; i++ {
-		key := randString((i % 15) + 5)
+	for i := 0; i < 1000; i++ {
+		key := randString((i % 199) + 1)
 		hash := mmh3.Hash32([]byte(key))
 		m := MurmurString(key)
 		if hash != m {
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
-	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -47,8 +46,8 @@ func TestMurmur(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 1000; i++ {
-		key := randString((i % 199) + 1)
+	for i := 0; i < 100; i++ {
+		key := randString((i % 15) + 5)
 		hash := mmh3.Hash32([]byte(key))
 		m := MurmurString(key)
 		if hash != m {
@@ -64,57 +63,4 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
-}
-
-// Benchmarks
-func benchmarkMurmer64(b *testing.B, input []uint64) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			Murmur64(x)
-		}
-	}
-}
-
-func benchmarkMurmerString(b *testing.B, input []string) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			MurmurString(x)
-		}
-	}
-}
-
-func benchmarkHash32(b *testing.B, input []string) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			b := *(*[]byte)(unsafe.Pointer(&x))
-			mmh3.Hash32(b)
-		}
-	}
-}
-
-func Benchmark100Murmer64(b *testing.B) {
-	input := make([]uint64, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = uint64(rand.Int63())
-	}
-	benchmarkMurmer64(b, input)
-}
-
-func Benchmark100MurmerString(b *testing.B) {
-	input := make([]string, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = randString((i % 15) + 5)
-	}
-	benchmarkMurmerString(b, input)
-}
-
-func Benchmark100Hash32(b *testing.B) {
-	input := make([]string, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = randString((i % 15) + 5)
-	}
-	benchmarkHash32(b, input)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -45,4 +45,22 @@ func TestMurmur(t *testing.T) {
 			t.Errorf("Hash mismatch on 128 bit %d,%d: expected 0x%X, got 0x%X\n", x, y, hash, m)
 		}
 	}
+
+	for i := 0; i < 100; i++ {
+		key := randString((i % 15) + 5)
+		hash := mmh3.Hash32([]byte(key))
+		m := MurmurString(key)
+		if hash != m {
+			t.Errorf("Hash mismatch on key %s: expected 0x%X, got 0x%X\n", key, hash, m)
+		}
+	}
+}
+
+func randString(n int) string {
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -10,6 +10,7 @@ import (
 
 var buf32 = make([]byte, 4)
 var buf64 = make([]byte, 8)
+var buf128 = make([]byte, 16)
 
 // Test that our abbreviated murmur hash works the same as upstream
 func TestMurmur(t *testing.T) {
@@ -30,6 +31,18 @@ func TestMurmur(t *testing.T) {
 		m := Murmur64(uint64(x))
 		if hash != m {
 			t.Errorf("Hash mismatch on 64 bit %d: expected 0x%X, got 0x%X\n", x, hash, m)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		x := rand.Int63()
+		y := rand.Int63()
+		binary.LittleEndian.PutUint64(buf128, uint64(x))
+		binary.LittleEndian.PutUint64(buf128[8:], uint64(y))
+		hash := mmh3.Hash32(buf128)
+		m := Murmur128(uint64(x), uint64(y))
+		if hash != m {
+			t.Errorf("Hash mismatch on 128 bit %d,%d: expected 0x%X, got 0x%X\n", x, y, hash, m)
 		}
 	}
 }


### PR DESCRIPTION
The first cast saves a call to `runtime.stringtoslicebyte` which takes about 400 ns/op. The second cast converts the four bytes with about half the number of instructions, which saves about 100 ns/op. I've spent a bunch of time staring at the following documents, and I *think* this is safe (for our current platform and current version of Go).

https://golang.org/pkg/unsafe/#Pointer
https://golang.org/pkg/reflect/#StringHeader

The go runtime could still break this in the future, but I've attempted to document that.

Before:

goos: darwin
goarch: amd64
pkg: github.com/DataDog/hyperloglog
Benchmark100MurmerString-4 1000000	1798 ns/op	0 B/op	0 allocs/op

After:

goos: darwin
goarch: amd64
pkg: github.com/DataDog/hyperloglog
Benchmark100MurmerString-4 2000000 1207 ns/op	0 B/op	0 allocs/op