### PR TITLE
[hyperloglog] Improve HLL performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ For a full description of the algorithm, see the paper HyperLogLog:
 the analysis of a near-optimal cardinality estimation algorithm by
 Flajolet, et. al. at http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
 
-For documentation see http://godoc.org/github.com/eclesh/hyperloglog
+For documentation see http://godoc.org/github.com/DataDog/hyperloglog
+
+Included are a set of fast implementations for murmurhash suitable for use
+on 32 and 64 bit integers on little endian machines.
 
 Quick start
 ===========
 
-	$ go get github.com/eclesh/hyperloglog
-	$ cd $GOPATH/src/github.com/eclesh/hyperloglog
+	$ go get github.com/DataDog/hyperloglog
+	$ cd $GOPATH/src/github.com/DataDog/hyperloglog
 	$ go test -test.v
 	$ go test -bench=.
 

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -11,10 +11,11 @@ package hyperloglog
 import (
 	"fmt"
 	"math"
+	"math/bits"
 )
 
-var (
-	exp32 = math.Pow(2, 32)
+const (
+	exp32 = 1 << 32 // 2^32
 )
 
 // A HyperLogLog is a deterministic cardinality estimator.  This version
@@ -58,7 +59,7 @@ func New(registers uint) (*HyperLogLog, error) {
 	}
 	h := &HyperLogLog{}
 	h.M = registers
-	h.B = uint32(math.Ceil(math.Log2(float64(registers))))
+	h.B = uint32(math.Log2(float64(registers)))
 	h.Alpha = getAlpha(registers)
 	h.Registers = make([]uint8, h.M)
 	return h, nil
@@ -71,21 +72,12 @@ func (h *HyperLogLog) Reset() {
 	}
 }
 
-// Calculate the position of the leftmost 1-bit.
-func rho(val uint32, max uint32) uint8 {
-	r := uint32(1)
-	for val&0x80000000 == 0 && r <= max {
-		r++
-		val <<= 1
-	}
-	return uint8(r)
-}
-
 // Add to the count. val should be a 32 bit unsigned integer from a
 // good hash function.
 func (h *HyperLogLog) Add(val uint32) {
 	k := 32 - h.B
-	r := rho(val<<h.B, k)
+	slice := val<<h.B | 1<<(h.B-1)
+	r := uint8(bits.LeadingZeros32(slice) + 1)
 	j := val >> uint(k)
 	if r > h.Registers[j] {
 		h.Registers[j] = r
@@ -110,7 +102,7 @@ func (h *HyperLogLog) count(withLargeRangeCorrection bool) uint64 {
 	sum := 0.0
 	m := float64(h.M)
 	for _, val := range h.Registers {
-		sum += 1.0 / math.Pow(2.0, float64(val))
+		sum += 1.0 / float64(int(1)<<val)
 	}
 	estimate := h.Alpha * m * m / sum
 	if estimate <= 5.0/2.0*m {

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -60,7 +60,7 @@ func New(registers uint) (*HyperLogLog, error) {
 	h.M = registers
 	h.B = uint32(math.Ceil(math.Log2(float64(registers))))
 	h.Alpha = getAlpha(registers)
-	h.Reset()
+	h.Registers = make([]uint8, h.M)
 	return h, nil
 }
 

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -49,9 +49,9 @@ func getAlpha(m uint) (result float64) {
 // of memory you're willing to use and the error you're willing to
 // tolerate. Each register uses one byte of memory.
 //
-// Approximate error will be:
-//     1.04 / sqrt(registers)
-//
+// Standard error will be: σ ≈ 1.04 / sqrt(registers)
+// The estimates provided by hyperloglog are expected to be within σ, 2σ, 3σ
+// of the exact count in respectively 65%, 95%, 99% of all the cases.
 func New(registers uint) (*HyperLogLog, error) {
 	if (registers & (registers - 1)) != 0 {
 		return nil, fmt.Errorf("number of registers %d not a power of two", registers)

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -66,7 +66,9 @@ func New(registers uint) (*HyperLogLog, error) {
 
 // Reset all internal variables and set the count to zero.
 func (h *HyperLogLog) Reset() {
-	h.Registers = make([]uint8, h.M)
+	for i := range h.Registers {
+		h.Registers[i] = 0
+	}
 }
 
 // Calculate the position of the leftmost 1-bit.

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -111,10 +111,9 @@ func (h *HyperLogLog) Count() uint64 {
 		if v > 0 {
 			estimate = m * math.Log(m/float64(v))
 		}
-	} else if estimate > 1.0/30.0*exp32 {
-		// Large range correction
-		estimate = -exp32 * math.Log(1-estimate/exp32)
 	}
+	// Not applying the large range correction proposed by Flajolet et al. as it leads to
+	// significant overcounting. See https://github.com/DataDog/hyperloglog/pull/15
 	return uint64(estimate)
 }
 

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -97,10 +97,16 @@ func testReset(t *testing.T, m uint, numObjects, runs int) {
 		for j := 0; j < numObjects; j++ {
 			h.Add(rand.Uint32())
 		}
-		h.Reset()
 
-		if h.Count() != 0 {
-			t.Errorf("reset failed, count=%d", h.Count())
+		oldRegisters := &h.Registers
+		h.Reset()
+		if oldRegisters != &h.Registers {
+			t.Error("registers were reallocated")
+		}
+		for _, r := range h.Registers {
+			if r != 0 {
+				t.Error("register is not zeroed out after reset")
+			}
 		}
 	}
 }

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"io"
 	"math"
+	"math/rand"
 	"os"
 	"testing"
 )
@@ -82,6 +83,30 @@ func TestHyperLogLogSmall(t *testing.T) {
 
 func TestHyperLogLogBig(t *testing.T) {
 	testHyperLogLog(t, 0, 4, 17)
+}
+
+func testReset(t *testing.T, m uint, numObjects, runs int) {
+	rand.Seed(101)
+
+	h, err := New(m)
+	if err != nil {
+		t.Fatalf("can't make New(%d): %v", m, err)
+	}
+
+	for i := 0; i < runs; i++ {
+		for j := 0; j < numObjects; j++ {
+			h.Add(rand.Uint32())
+		}
+		h.Reset()
+
+		if h.Count() != 0 {
+			t.Errorf("reset failed, count=%d", h.Count())
+		}
+	}
+}
+
+func TestReset(t *testing.T) {
+	testReset(t, 512, 1_000_000, 10)
 }
 
 func benchmarkCount(b *testing.B, registers int) {

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -124,6 +124,8 @@ func BenchmarkReset(b *testing.B) {
 		b.Fatalf("can't make New(%d): %v", m, err)
 	}
 
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < numObjects; i++ {
 			h.Add(uint32(i))

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -111,26 +111,25 @@ func testReset(t *testing.T, m uint, numObjects, runs int) {
 	}
 }
 
-func benchmarkReset(b *testing.B, h *HyperLogLog, numObjects int) {
+func TestReset(t *testing.T) {
+	testReset(t, 512, 1_000_000, 10)
+}
+
+func BenchmarkReset(b *testing.B) {
+	m := uint(256)
+	numObjects := 1000
+
+	h, err := New(m)
+	if err != nil {
+		b.Fatalf("can't make New(%d): %v", m, err)
+	}
+
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < numObjects; i++ {
 			h.Add(uint32(i))
 		}
 		h.Reset()
 	}
-}
-
-func TestReset(t *testing.T) {
-	testReset(t, 512, 1_000_000, 10)
-}
-
-func BenchmarkReset(b *testing.B) {
-	h, err := New(256)
-	if err != nil {
-		b.Fatalf("can't make New(256): %v", err)
-	}
-
-	benchmarkReset(b, h, 1000)
 }
 
 func benchmarkCount(b *testing.B, registers int) {

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -84,22 +84,6 @@ func TestHyperLogLogBig(t *testing.T) {
 	testHyperLogLog(t, 0, 4, 17)
 }
 
-func TestMurmurBytes(t *testing.T) {
-	b := []byte("hello")
-	v := MurmurBytes(b)
-	if v != 613153351 {
-		t.Fatalf("MurmurBytes failed for %s: %v != %v", b, v, 613153351)
-	}
-}
-
-func TestMurmurString(t *testing.T) {
-	s := "hello"
-	v := MurmurString(s)
-	if v != 613153351 {
-		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
-	}
-}
-
 func benchmarkCount(b *testing.B, registers int) {
 	words := dictionary(0)
 	m := uint(math.Pow(2, float64(registers)))

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -84,6 +84,22 @@ func TestHyperLogLogBig(t *testing.T) {
 	testHyperLogLog(t, 0, 4, 17)
 }
 
+func TestMurmurBytes(t *testing.T) {
+	b := []byte("hello")
+	v := MurmurBytes(b)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", b, v, 613153351)
+	}
+}
+
+func TestMurmurString(t *testing.T) {
+	s := "hello"
+	v := MurmurString(s)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
+	}
+}
+
 func benchmarkCount(b *testing.B, registers int) {
 	words := dictionary(0)
 	m := uint(math.Pow(2, float64(registers)))

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -44,11 +44,11 @@ func geterror(actual uint64, estimate uint64) (result float64) {
 	return (float64(estimate) - float64(actual)) / float64(actual)
 }
 
-func testHyperLogLog(t *testing.T, n, low_b, high_b int) {
+func testHyperLogLog(t *testing.T, n, lowB, highB int) {
 	words := dictionary(n)
 	bad := 0
-	n_words := uint64(len(words))
-	for i := low_b; i < high_b; i++ {
+	nWords := uint64(len(words))
+	for i := lowB; i < highB; i++ {
 		m := uint(math.Pow(2, float64(i)))
 
 		h, err := New(m)
@@ -63,17 +63,17 @@ func testHyperLogLog(t *testing.T, n, low_b, high_b int) {
 			hash.Reset()
 		}
 
-		expected_error := 1.04 / math.Sqrt(float64(m))
-		actual_error := math.Abs(geterror(n_words, h.Count()))
+		expectedError := 1.04 / math.Sqrt(float64(m))
+		actualError := math.Abs(geterror(nWords, h.Count()))
 
-		if actual_error > expected_error {
+		if actualError > expectedError {
 			bad++
 			t.Logf("m=%d: error=%.5f, expected <%.5f; actual=%d, estimated=%d\n",
-				m, actual_error, expected_error, n_words, h.Count())
+				m, actualError, expectedError, nWords, h.Count())
 		}
 
 	}
-	t.Logf("%d of %d tests exceeded estimated error", bad, high_b-low_b)
+	t.Logf("%d of %d tests exceeded estimated error", bad, highB-lowB)
 }
 
 func TestHyperLogLogSmall(t *testing.T) {

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -111,8 +111,26 @@ func testReset(t *testing.T, m uint, numObjects, runs int) {
 	}
 }
 
+func benchmarkReset(b *testing.B, h *HyperLogLog, numObjects int) {
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < numObjects; i++ {
+			h.Add(uint32(i))
+		}
+		h.Reset()
+	}
+}
+
 func TestReset(t *testing.T) {
 	testReset(t, 512, 1_000_000, 10)
+}
+
+func BenchmarkReset(b *testing.B) {
+	h, err := New(256)
+	if err != nil {
+		b.Fatalf("can't make New(256): %v", err)
+	}
+
+	benchmarkReset(b, h, 1000)
 }
 
 func benchmarkCount(b *testing.B, registers int) {

--- a/murmur.go
+++ b/murmur.go
@@ -35,7 +35,8 @@ func MurmurBytes(bkey []byte) uint32 {
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
+		data := bkey[i*4 : (i*4)+4]
+		k := uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
 
 		// encode next 4 byte chunk of `key'
 		k *= c1

--- a/murmur.go
+++ b/murmur.go
@@ -56,3 +56,51 @@ func Murmur64(i uint64) uint32 {
 	h ^= h >> 16
 	return h
 }
+
+// Murmur128 implements a fast version of the murmur hash function for two uint64s
+// for little endian machines.  Suitable for adding a 128bit value to an HLL counter.
+func Murmur128(i, j uint64) uint32 {
+	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
+	var h, k uint32
+	//first 4-byte chunk
+	k = uint32(i)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second 4-byte chunk
+	k = uint32(i >> 32)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// third 4-byte chunk
+	k = uint32(j)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// fourth 4-byte chunk
+	k = uint32(j >> 32)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second part
+	h ^= 16
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+
+}

--- a/murmur.go
+++ b/murmur.go
@@ -13,6 +13,9 @@ import (
 // MurmurString implements a fast version of the murmur hash function for strings
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
+	if len(key) == 0 {
+		return MurmurBytes(nil)
+	}
 	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
 	byteSlice := (*[math.MaxInt32 - 1]byte)(unsafe.Pointer(sh.Data))[:sh.Len:sh.Len]

--- a/murmur.go
+++ b/murmur.go
@@ -11,13 +11,18 @@ import (
 // MurmurString implements a fast version of the murmur hash function for strings
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
+	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
+	return MurmurBytes(bkey)
+}
+
+// MurmurBytes implements a fast version of the murmur hash function for bytes
+// for little endian machines.  Suitable for adding strings to HLL counter.
+func MurmurBytes(bkey []byte) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
-
 	l := blen / 4 // chunk length
 	tail := bkey[l*4:]
 

--- a/murmur.go
+++ b/murmur.go
@@ -1,0 +1,58 @@
+package hyperloglog
+
+// This file implements the murmur3 32-bit hash on 32bit and 64bit integers
+// for little endian machines only with no heap allocation.  If you are using
+// HLL to count integer IDs on intel machines, this is your huckleberry.
+
+// Murmur32 implements a fast version of the murmur hash function for uint32 for
+// little endian machines.  Suitable for adding 32bit integers to a HLL counter.
+func Murmur32(i uint32) uint32 {
+	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
+	var h, k uint32
+	k = i
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second part
+	h ^= 4
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}
+
+// Murmur64 implements a fast version of the murmur hash function for uint64 for
+// little endian machines.  Suitable for adding 64bit integers to a HLL counter.
+func Murmur64(i uint64) uint32 {
+	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
+	var h, k uint32
+	//first 4-byte chunk
+	k = uint32(i)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second 4-byte chunk
+	k = uint32(i >> 32)
+	k *= c1
+	k = (k << 15) | (k >> (32 - 15))
+	k *= c2
+	h ^= k
+	h = (h << 13) | (h >> (32 - 13))
+	h = (h * 5) + 0xe6546b64
+	// second part
+	h ^= 8
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}

--- a/murmur.go
+++ b/murmur.go
@@ -1,8 +1,6 @@
 package hyperloglog
 
-import (
-	"encoding/binary"
-)
+import "unsafe"
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
 // for little endian machines only with no heap allocation.  If you are using
@@ -14,17 +12,14 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := make([]byte, len(key))
-	copy(bkey[:], key)
-
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
 	l := blen / 4 // chunk length
-	tail := bkey[l*4:]
 
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = binary.LittleEndian.Uint32(bkey[i*4:])
+		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
 
 		// encode next 4 byte chunk of `key'
 		k *= c1
@@ -37,7 +32,8 @@ func MurmurString(key string) uint32 {
 
 	k = 0
 	// remainder
-	switch len(tail) {
+	tail := bkey[l*4:]
+	switch blen % 4 {
 	case 3:
 		k ^= uint32(tail[2]) << 16
 		fallthrough

--- a/murmur.go
+++ b/murmur.go
@@ -14,9 +14,10 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := []byte(key)
-	blen := len(bkey)
+	bkey := make([]byte, len(key))
+	copy(bkey[:], key)
 
+	blen := len(bkey)
 	l := blen / 4 // chunk length
 	tail := bkey[l*4:]
 

--- a/murmur.go
+++ b/murmur.go
@@ -1,8 +1,6 @@
 package hyperloglog
 
 import (
-	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -16,15 +14,8 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	// Reinterpret the string as a `StringHeader`. This comes with three important caveats:
-	// 1. We must never write through the pointer derived. Golang strings are immutable and we cannot
-	//    break that assumption.
-	// 2. Golang continues to have a non-moving GC. This only works because the Golang GC is
-	//    (currently) non-moving. There are no plans to break this yet, but it remains a caveat.
-	// 3. `key` is used after the `StringHeader` is no longer needed. Currently, `runtime.KeepAlive`
-	//    is used as a no-op use.
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
-	bkey := *(*[]byte)(unsafe.Pointer(sh))
+	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
 
 	l := blen / 4 // chunk length
@@ -67,8 +58,6 @@ func MurmurString(key string) uint32 {
 	h ^= (h >> 13)
 	h *= 0xc2b2ae35
 	h ^= (h >> 16)
-
-	runtime.KeepAlive(&key)
 
 	return h
 }

--- a/murmur.go
+++ b/murmur.go
@@ -16,12 +16,9 @@ func MurmurString(key string) uint32 {
 	blen := len(bkey)
 	l := blen / 4 // chunk length
 
-	// for each 4 byte chunk of `key'
+	// encode each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
-		// next 4 byte chunk of `key'
 		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
-
-		// encode next 4 byte chunk of `key'
 		k *= c1
 		k = (k << 15) | (k >> (32 - 15))
 		k *= c2
@@ -31,21 +28,23 @@ func MurmurString(key string) uint32 {
 	}
 
 	k = 0
-	// remainder
-	tail := bkey[l*4:]
-	switch blen % 4 {
-	case 3:
-		k ^= uint32(tail[2]) << 16
-		fallthrough
-	case 2:
-		k ^= uint32(tail[1]) << 8
-		fallthrough
-	case 1:
-		k ^= uint32(tail[0])
-		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
-		k *= c2
-		h ^= k
+	//remainder
+	if mod := blen % 4; mod > 0 {
+		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
+		switch mod {
+		case 3:
+			k ^= ((btail >> 16) & 0x0000FFFF) << 16
+			fallthrough
+		case 2:
+			k ^= ((btail >> 8) & 0x000000FF) << 8
+			fallthrough
+		case 1:
+			k ^= btail & 0x000000FF
+			k *= c1
+			k = (k << 15) | (k >> (32 - 15))
+			k *= c2
+			h ^= k
+		}
 	}
 
 	h ^= uint32(blen)

--- a/murmur.go
+++ b/murmur.go
@@ -1,7 +1,9 @@
 package hyperloglog
 
 import (
-	"encoding/binary"
+	"reflect"
+	"runtime"
+	"unsafe"
 )
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
@@ -14,7 +16,15 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := []byte(key)
+	// Reinterpret the string as a `StringHeader`. This comes with three important caveats:
+	// 1. We must never write through the pointer derived. Golang strings are immutable and we cannot
+	//    break that assumption.
+	// 2. Golang continues to have a non-moving GC. This only works because the Golang GC is
+	//    (currently) non-moving. There are no plans to break this yet, but it remains a caveat.
+	// 3. `key` is used after the `StringHeader` is no longer needed. Currently, `runtime.KeepAlive`
+	//    is used as a no-op use.
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	bkey := *(*[]byte)(unsafe.Pointer(sh))
 	blen := len(bkey)
 
 	l := blen / 4 // chunk length
@@ -23,7 +33,7 @@ func MurmurString(key string) uint32 {
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = binary.LittleEndian.Uint32(bkey[i*4:])
+		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
 
 		// encode next 4 byte chunk of `key'
 		k *= c1
@@ -57,6 +67,9 @@ func MurmurString(key string) uint32 {
 	h ^= (h >> 13)
 	h *= 0xc2b2ae35
 	h ^= (h >> 16)
+
+	runtime.KeepAlive(&key)
+
 	return h
 }
 

--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,8 @@
 package hyperloglog
 
-import "unsafe"
+import (
+	"encoding/binary"
+)
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
 // for little endian machines only with no heap allocation.  If you are using
@@ -12,13 +14,18 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
+	bkey := []byte(key)
 	blen := len(bkey)
-	l := blen / 4 // chunk length
 
-	// encode each 4 byte chunk of `key'
+	l := blen / 4 // chunk length
+	tail := bkey[l*4:]
+
+	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
-		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
+		// next 4 byte chunk of `key'
+		k = binary.LittleEndian.Uint32(bkey[i*4:])
+
+		// encode next 4 byte chunk of `key'
 		k *= c1
 		k = (k << 15) | (k >> (32 - 15))
 		k *= c2
@@ -28,23 +35,20 @@ func MurmurString(key string) uint32 {
 	}
 
 	k = 0
-	//remainder
-	if mod := blen % 4; mod > 0 {
-		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
-		switch mod {
-		case 3:
-			k ^= ((btail >> 16) & 0x000000FF) << 16
-			fallthrough
-		case 2:
-			k ^= ((btail >> 8) & 0x000000FF) << 8
-			fallthrough
-		case 1:
-			k ^= btail & 0x000000FF
-			k *= c1
-			k = (k << 15) | (k >> (32 - 15))
-			k *= c2
-			h ^= k
-		}
+	// remainder
+	switch len(tail) {
+	case 3:
+		k ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k ^= uint32(tail[0])
+		k *= c1
+		k = (k << 15) | (k >> (32 - 15))
+		k *= c2
+		h ^= k
 	}
 
 	h ^= uint32(blen)

--- a/murmur.go
+++ b/murmur.go
@@ -2,6 +2,7 @@ package hyperloglog
 
 import (
 	"math"
+	"math/bits"
 	"reflect"
 	"unsafe"
 )
@@ -26,50 +27,48 @@ func MurmurString(key string) uint32 {
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurBytes(bkey []byte) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
-	var h, k uint32
+	var h uint32
 
 	blen := len(bkey)
-	l := blen / 4 // chunk length
-	tail := bkey[l*4:]
+	chunks := blen / 4 // chunk length
 
-	// for each 4 byte chunk of `key'
-	for i := 0; i < l; i++ {
-		// next 4 byte chunk of `key'
-		data := bkey[i*4 : (i*4)+4]
-		k := uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
+	values := (*(*[]uint32)(unsafe.Pointer(&bkey)))[:chunks:chunks]
 
-		// encode next 4 byte chunk of `key'
+	for _, k := range values {
 		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
+		k = bits.RotateLeft32(k, 15)
 		k *= c2
+
 		h ^= k
-		h = (h << 13) | (h >> (32 - 13))
+		h = bits.RotateLeft32(h, 13)
 		h = (h * 5) + 0xe6546b64
 	}
 
-	k = 0
+	var k uint32
+	tailLength := blen % 4
+	tailStart := blen - tailLength
 	// remainder
-	switch len(tail) {
+	switch tailLength {
 	case 3:
-		k ^= uint32(tail[2]) << 16
+		k ^= uint32(bkey[tailStart+2]) << 16
 		fallthrough
 	case 2:
-		k ^= uint32(tail[1]) << 8
+		k ^= uint32(bkey[tailStart+1]) << 8
 		fallthrough
 	case 1:
-		k ^= uint32(tail[0])
+		k ^= uint32(bkey[tailStart])
 		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
+		k = bits.RotateLeft32(k, 15)
 		k *= c2
 		h ^= k
 	}
 
 	h ^= uint32(blen)
-	h ^= (h >> 16)
+	h ^= h >> 16
 	h *= 0x85ebca6b
-	h ^= (h >> 13)
+	h ^= h >> 13
 	h *= 0xc2b2ae35
-	h ^= (h >> 16)
+	h ^= h >> 16
 
 	return h
 }

--- a/murmur.go
+++ b/murmur.go
@@ -33,7 +33,7 @@ func MurmurString(key string) uint32 {
 		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
 		switch mod {
 		case 3:
-			k ^= ((btail >> 16) & 0x0000FFFF) << 16
+			k ^= ((btail >> 16) & 0x000000FF) << 16
 			fallthrough
 		case 2:
 			k ^= ((btail >> 8) & 0x000000FF) << 8

--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,7 @@
 package hyperloglog
 
 import (
+	"reflect"
 	"unsafe"
 )
 
@@ -12,8 +13,13 @@ import (
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
 	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
-	return MurmurBytes(bkey)
+	b := make([]byte, 0)
+	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	sHeader := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	bHeader.Data = sHeader.Data
+	bHeader.Len = sHeader.Len
+	bHeader.Cap = sHeader.Len
+	return MurmurBytes(b)
 }
 
 // MurmurBytes implements a fast version of the murmur hash function for bytes

--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,7 @@
 package hyperloglog
 
 import (
+	"math"
 	"reflect"
 	"unsafe"
 )
@@ -13,13 +14,9 @@ import (
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
 	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
-	b := make([]byte, 0)
-	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sHeader := (*reflect.StringHeader)(unsafe.Pointer(&key))
-	bHeader.Data = sHeader.Data
-	bHeader.Len = sHeader.Len
-	bHeader.Cap = sHeader.Len
-	return MurmurBytes(b)
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	byteSlice := (*[math.MaxInt32 - 1]byte)(unsafe.Pointer(sh.Data))[:sh.Len:sh.Len]
+	return MurmurBytes(byteSlice)
 }
 
 // MurmurBytes implements a fast version of the murmur hash function for bytes

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/reusee/mmh3"
+	"github.com/DataDog/mmh3"
 )
 
 var buf32 = make([]byte, 4)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,0 +1,35 @@
+package hyperloglog
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/reusee/mmh3"
+)
+
+var buf32 = make([]byte, 4)
+var buf64 = make([]byte, 8)
+
+// Test that our abbreviated murmur hash works the same as upstream
+func TestMurmur(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		x := rand.Int31()
+		binary.LittleEndian.PutUint32(buf32, uint32(x))
+		hash := mmh3.Hash32(buf32)
+		m := Murmur32(uint32(x))
+		if hash != m {
+			t.Errorf("Hash mismatch on 32 bit %d: expected 0x%X, got 0x%X\n", x, hash, m)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		x := rand.Int63()
+		binary.LittleEndian.PutUint64(buf64, uint64(x))
+		hash := mmh3.Hash32(buf64)
+		m := Murmur64(uint64(x))
+		if hash != m {
+			t.Errorf("Hash mismatch on 64 bit %d: expected 0x%X, got 0x%X\n", x, hash, m)
+		}
+	}
+}

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -57,6 +57,22 @@ func TestMurmur(t *testing.T) {
 	}
 }
 
+func TestMurmurBytes(t *testing.T) {
+	b := []byte("hello")
+	v := MurmurBytes(b)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", b, v, 613153351)
+	}
+}
+
+func TestMurmurString(t *testing.T) {
+	s := "hello"
+	v := MurmurString(s)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
+	}
+}
+
 func randString(n int) string {
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -69,7 +69,7 @@ func TestMurmurString(t *testing.T) {
 	s := "hello"
 	v := MurmurString(s)
 	if v != 613153351 {
-		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
+		t.Fatalf("MurmurString failed for %s: %v != %v", s, v, 613153351)
 	}
 }
 
@@ -83,7 +83,7 @@ func randString(n int) string {
 }
 
 // Benchmarks
-func benchmarkMurmer64(b *testing.B, input []uint64) {
+func benchmarkMurmur64(b *testing.B, input []uint64) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for _, x := range input {
@@ -92,7 +92,7 @@ func benchmarkMurmer64(b *testing.B, input []uint64) {
 	}
 }
 
-func benchmarkMurmerString(b *testing.B, input []string) {
+func benchmarkMurmurString(b *testing.B, input []string) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for _, x := range input {
@@ -111,20 +111,20 @@ func benchmarkHash32(b *testing.B, input []string) {
 	}
 }
 
-func Benchmark100Murmer64(b *testing.B) {
+func Benchmark100Murmur64(b *testing.B) {
 	input := make([]uint64, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = uint64(rand.Int63())
 	}
-	benchmarkMurmer64(b, input)
+	benchmarkMurmur64(b, input)
 }
 
-func Benchmark100MurmerString(b *testing.B) {
+func Benchmark100MurmurString(b *testing.B) {
 	input := make([]string, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = randString((i % 15) + 5)
 	}
-	benchmarkMurmerString(b, input)
+	benchmarkMurmurString(b, input)
 }
 
 func Benchmark100Hash32(b *testing.B) {

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/mmh3"
+	"github.com/dustin/randbo"
 )
 
 var buf32 = make([]byte, 4)
@@ -133,4 +134,19 @@ func Benchmark100Hash32(b *testing.B) {
 		input[i] = randString((i % 15) + 5)
 	}
 	benchmarkHash32(b, input)
+}
+
+func BenchmarkMurmurStringBig(b *testing.B) {
+	// Make a 100Mb string and use that as a benchmark
+	r := randbo.New()
+	slice := make([]byte, 100*1024*1024)
+	_, err := r.Read(slice)
+	if err != nil {
+		b.Fatalf("Failed to create benchmark data: %s", err)
+	}
+	s := string(slice)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MurmurString(s)
+	}
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -46,8 +47,8 @@ func TestMurmur(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 100; i++ {
-		key := randString((i % 15) + 5)
+	for i := 0; i < 1000; i++ {
+		key := randString((i % 199) + 1)
 		hash := mmh3.Hash32([]byte(key))
 		m := MurmurString(key)
 		if hash != m {
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
-	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -47,8 +46,8 @@ func TestMurmur(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 1000; i++ {
-		key := randString((i % 199) + 1)
+	for i := 0; i < 100; i++ {
+		key := randString((i % 15) + 5)
 		hash := mmh3.Hash32([]byte(key))
 		m := MurmurString(key)
 		if hash != m {
@@ -64,57 +63,4 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
-}
-
-// Benchmarks
-func benchmarkMurmer64(b *testing.B, input []uint64) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			Murmur64(x)
-		}
-	}
-}
-
-func benchmarkMurmerString(b *testing.B, input []string) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			MurmurString(x)
-		}
-	}
-}
-
-func benchmarkHash32(b *testing.B, input []string) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			b := *(*[]byte)(unsafe.Pointer(&x))
-			mmh3.Hash32(b)
-		}
-	}
-}
-
-func Benchmark100Murmer64(b *testing.B) {
-	input := make([]uint64, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = uint64(rand.Int63())
-	}
-	benchmarkMurmer64(b, input)
-}
-
-func Benchmark100MurmerString(b *testing.B) {
-	input := make([]string, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = randString((i % 15) + 5)
-	}
-	benchmarkMurmerString(b, input)
-}
-
-func Benchmark100Hash32(b *testing.B) {
-	input := make([]string, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = randString((i % 15) + 5)
-	}
-	benchmarkHash32(b, input)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -45,4 +45,22 @@ func TestMurmur(t *testing.T) {
 			t.Errorf("Hash mismatch on 128 bit %d,%d: expected 0x%X, got 0x%X\n", x, y, hash, m)
 		}
 	}
+
+	for i := 0; i < 100; i++ {
+		key := randString((i % 15) + 5)
+		hash := mmh3.Hash32([]byte(key))
+		m := MurmurString(key)
+		if hash != m {
+			t.Errorf("Hash mismatch on key %s: expected 0x%X, got 0x%X\n", key, hash, m)
+		}
+	}
+}
+
+func randString(n int) string {
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -83,6 +83,7 @@ func TestMurmurStringZero(t *testing.T) {
 }
 
 func randString(n int) string {
+	rand.Seed(10)
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)
 	for i := range b {
@@ -92,6 +93,15 @@ func randString(n int) string {
 }
 
 // Benchmarks
+func benchmarkMurmurBytes(b *testing.B, input [][]byte) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurBytes(x)
+		}
+	}
+}
+
 func benchmarkMurmur64(b *testing.B, input []uint64) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -120,7 +130,19 @@ func benchmarkHash32(b *testing.B, input []string) {
 	}
 }
 
+func Benchmark100MurmurBytes(b *testing.B) {
+	rand.Seed(10)
+	input := make([][]byte, 100)
+	for i := 0; i < 100; i++ {
+		x := make([]byte, 1000)
+		rand.Read(x)
+		input[i] = x
+	}
+	benchmarkMurmurBytes(b, input)
+}
+
 func Benchmark100Murmur64(b *testing.B) {
+	rand.Seed(10)
 	input := make([]uint64, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = uint64(rand.Int63())
@@ -129,6 +151,7 @@ func Benchmark100Murmur64(b *testing.B) {
 }
 
 func Benchmark100MurmurString(b *testing.B) {
+	rand.Seed(10)
 	input := make([]string, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = randString((i % 15) + 5)
@@ -137,6 +160,7 @@ func Benchmark100MurmurString(b *testing.B) {
 }
 
 func Benchmark100Hash32(b *testing.B) {
+	rand.Seed(10)
 	input := make([]string, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = randString((i % 15) + 5)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -74,6 +74,14 @@ func TestMurmurString(t *testing.T) {
 	}
 }
 
+func TestMurmurStringZero(t *testing.T) {
+	s := ""
+	v := MurmurString(s)
+	if v != 0 {
+		t.Fatalf("MurmurString failed for %s: %v != %v", s, v, 0)
+	}
+}
+
 func randString(n int) string {
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -10,6 +10,7 @@ import (
 
 var buf32 = make([]byte, 4)
 var buf64 = make([]byte, 8)
+var buf128 = make([]byte, 16)
 
 // Test that our abbreviated murmur hash works the same as upstream
 func TestMurmur(t *testing.T) {
@@ -30,6 +31,18 @@ func TestMurmur(t *testing.T) {
 		m := Murmur64(uint64(x))
 		if hash != m {
 			t.Errorf("Hash mismatch on 64 bit %d: expected 0x%X, got 0x%X\n", x, hash, m)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		x := rand.Int63()
+		y := rand.Int63()
+		binary.LittleEndian.PutUint64(buf128, uint64(x))
+		binary.LittleEndian.PutUint64(buf128[8:], uint64(y))
+		hash := mmh3.Hash32(buf128)
+		m := Murmur128(uint64(x), uint64(y))
+		if hash != m {
+			t.Errorf("Hash mismatch on 128 bit %d,%d: expected 0x%X, got 0x%X\n", x, y, hash, m)
 		}
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
Replaces `rho()` with the stdlib `bits.LeadingZeros32()`, which is intrinsified on amd64 and arm64 and accomplishes the same task (counting the number of leading zeroes in the bit representation of a value) with improved performance. 

Replaces a few calls to the `math` library with bit manipulation, which is less performance intensive

Additional Notes
----------------
Benchmarks indicate significant performance improvements compared to the previous version of HLL: 
```
name                old time/op  new time/op  delta
Reset-10            6.40µs ± 0%  1.36µs ± 0%   ~     (p=1.000 n=1+1)
Count4-10            222ns ± 0%    10ns ± 0%   ~     (p=1.000 n=1+1)
Count5-10            490ns ± 0%    20ns ± 0%   ~     (p=1.000 n=1+1)
Count6-10            915ns ± 0%    46ns ± 0%   ~     (p=1.000 n=1+1)
Count7-10           2.14µs ± 0%  0.10µs ± 0%   ~     (p=1.000 n=1+1)
Count8-10           4.74µs ± 0%  0.21µs ± 0%   ~     (p=1.000 n=1+1)
Count9-10           10.9µs ± 0%   0.5µs ± 0%   ~     (p=1.000 n=1+1)
Count10-10          23.7µs ± 0%   1.0µs ± 0%   ~     (p=1.000 n=1+1)
100MurmurBytes-10   43.0µs ± 0%  42.8µs ± 0%   ~     (p=1.000 n=1+1)
100Murmur64-10       256ns ± 0%   257ns ± 0%   ~     (p=1.000 n=1+1)
100MurmurString-10   629ns ± 0%   629ns ± 0%   ~     (p=1.000 n=1+1)
100Hash32-10         690ns ± 0%   691ns ± 0%   ~     (p=1.000 n=1+1)
MurmurStringBig-10  46.4ms ± 0%  46.7ms ± 0%   ~     (p=1.000 n=1+1)
```
Benchmarks prior to this PR: 
```
BenchmarkReset-10              	  156872	      6405 ns/op
BenchmarkCount4-10             	 5422813	       222.4 ns/op
BenchmarkCount5-10             	 2498756	       490.3 ns/op
BenchmarkCount6-10             	 1299194	       915.0 ns/op
BenchmarkCount7-10             	  546396	      2143 ns/op
BenchmarkCount8-10             	  246973	      4740 ns/op
BenchmarkCount9-10             	  109562	     10890 ns/op
BenchmarkCount10-10            	   50743	     23733 ns/op
Benchmark100MurmurBytes-10     	   28096	     43042 ns/op
Benchmark100Murmur64-10        	 4674187	       255.8 ns/op
Benchmark100MurmurString-10    	 1897222	       629.3 ns/op
Benchmark100Hash32-10          	 1743304	       689.8 ns/op
BenchmarkMurmurStringBig-10    	      25	  46412977 ns/op
```
Benchmarks after this PR's changes:
```
BenchmarkReset-10              	  879480	      1356 ns/op
BenchmarkCount4-10             	100000000	        10.21 ns/op
BenchmarkCount5-10             	57705370	        20.36 ns/op
BenchmarkCount6-10             	26007872	        45.84 ns/op
BenchmarkCount7-10             	12631954	        95.46 ns/op
BenchmarkCount8-10             	 5594330	       214.9 ns/op
BenchmarkCount9-10             	 2608581	       459.3 ns/op
BenchmarkCount10-10            	 1259529	       957.8 ns/op
Benchmark100MurmurBytes-10     	   28106	     42812 ns/op
Benchmark100Murmur64-10        	 4693041	       256.9 ns/op
Benchmark100MurmurString-10    	 1902806	       629.2 ns/op
Benchmark100Hash32-10          	 1741650	       691.0 ns/op
BenchmarkMurmurStringBig-10    	      25	  46652778 ns/op
```